### PR TITLE
Idenfied and fixed unintended behavior with user_file_selection() function

### DIFF
--- a/ictoolkit/directors/file_director.py
+++ b/ictoolkit/directors/file_director.py
@@ -540,6 +540,3 @@ def user_file_selection(prompt: str, criteria: str, root_dir=None) -> str:
         else:
             # Valid input provided, return absolute path of file selected
             return files[selection]
-
-
-print(user_file_selection("Get them DBs:", "*.db", "C:\\Cloud\\NextCloud\\Programming\\Python\\Scripts\\Team\\icsqltools\\icsqltools\\tests\\sql"))

--- a/ictoolkit/directors/file_director.py
+++ b/ictoolkit/directors/file_director.py
@@ -493,7 +493,7 @@ def user_file_selection(prompt: str, criteria: str, root_dir=None) -> str:
     """
     if root_dir:
         # Use provided root directory for search
-        search_path = os.path.dirname(root_dir)
+        search_path = root_dir
     else:
         # If path not provided, use current working directory
         search_path = os.path.abspath(os.curdir)
@@ -540,3 +540,6 @@ def user_file_selection(prompt: str, criteria: str, root_dir=None) -> str:
         else:
             # Valid input provided, return absolute path of file selected
             return files[selection]
+
+
+print(user_file_selection("Get them DBs:", "*.db", "C:\\Cloud\\NextCloud\\Programming\\Python\\Scripts\\Team\\icsqltools\\icsqltools\\tests\\sql"))

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = '0.0.7.8'
+VERSION = '0.0.7.9'
 DESCRIPTION = 'ictoolkit is designed to be the swiss army knife of programming methods.'
 LONG_DESCRIPTION = 'Each method is broken down into a specific type of use case. The methods are currently broad and cover several types of areas.'
 


### PR DESCRIPTION
Discovered that the os.path.basename() is simple in nature. When passed a full path with a filename included, it strips the filename as expected. However, when passed only a directory, it will strip the last sub-directory which is isn't expected.